### PR TITLE
fix: edit trip odometer/GPS fallback, deploy.sh state file, API Gateway stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ node_modules/
 met_outputs.json
 ios/**/met_outputs.json
 
+# Deploy state (persists API Gateway ID between deploys — never commit)
+.met_deploy_state
+
 # macOS
 .DS_Store
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,14 +49,14 @@ BASE_OUTPUTS_PATH=/path/to/cognito-s3-stack-893/base_outputs.json \
 - `backend/lambda/ocr/` — S3 trigger → Textract
 - `backend/scripts/deploy.sh` — idempotent pre-checks, env var overrides, writes met_outputs.json
 
-## Deployed values — dliv893 (your personal deployment on dlivFriendsProd)
-- Stack:           MileageExpenseStack-dliv893
-- API Gateway:     a4zm91fvsl — https://a4zm91fvsl.execute-api.us-east-1.amazonaws.com/prod/
-- User Pool:       us-east-1_A4MFXeYS7 (dlivFriendsProd)
-- App Client:      7d9fi2r1ksr3u127mmjj4tmh1b (dliv893-met-client)
-- Identity Pool:   us-east-1:479c2bb8-9c6a-4bc6-a86a-194547716177
-- Receipts bucket: dliv893-met-receipts
-- Tables:          dliv893-met-vehicles, dliv893-met-trips, dliv893-met-expenses
+## Deployed values — apps-893 (current active deployment on us-east-1_Iijv2ET6V)
+- Stack:           MileageExpenseStack-apps-893
+- API Gateway:     n5154qou80 — https://n5154qou80.execute-api.us-east-1.amazonaws.com/prod/
+- User Pool:       us-east-1_Iijv2ET6V
+- App Client:      1d0mnj8j3o26hih4sjdomub19t (apps-893-met-client)
+- Identity Pool:   us-east-1:cd8da7d7-bfb5-48c8-bcaf-1021020185b6
+- Receipts bucket: apps-893-met-receipts
+- Tables:          apps-893-met-vehicles, apps-893-met-trips, apps-893-met-expenses
 
 ## Old deployed values — met893 (deprecated, on dlivFriendsDev)
 - Stack:           MileageExpenseStack-met893 (old root-level stack, stale)
@@ -67,11 +67,12 @@ BASE_OUTPUTS_PATH=/path/to/cognito-s3-stack-893/base_outputs.json \
 - Receipts bucket: met893-receipts (data retained, not migrated yet)
 - Tables:          met893-vehicles, met893-trips, met893-expenses (data retained, not migrated yet)
 
-## Redeploy command (your personal deployment)
+## Redeploy command (apps-893 active deployment)
 ```bash
-cd /Users/ltm893/Dev/projects/mileage-expense-tracker-893/backend
-ID_PREFIX=dliv893 \
-USER_POOL_ID=us-east-1_A4MFXeYS7 \
+cd /Users/ltm893/Dev/projects/apps-893/mileage-expense-tracker-893/backend
+AWS_PROFILE=dliv-admin \
+ID_PREFIX=apps-893 \
+USER_POOL_ID=us-east-1_Iijv2ET6V \
 AWS_REGION=us-east-1 \
   ./scripts/deploy.sh
 ```

--- a/backend/lib/met-stack.ts
+++ b/backend/lib/met-stack.ts
@@ -241,11 +241,10 @@ export class MileageExpenseStack extends cdk.Stack {
     expense.addMethod("DELETE", new apigateway.LambdaIntegration(expensesLambda), authOptions);
 
     // ── Outputs ───────────────────────────────────────────────────────────────
-    // When API is imported (metApiId set), api.url is not available on IRestApi.
-    // Reconstruct the URL from the known ID and region instead.
-    const apiUrl = metApiId
-      ? `https://${metApiId}.execute-api.${base.aws_region}.amazonaws.com/prod/`
-      : (api as apigateway.RestApi).url;
+    // Always reconstruct the URL from the actual API ID — never rely on
+    // api.url from an imported IRestApi as it may reflect a stale/deleted ID.
+    const resolvedApiId = metApiId ?? (api as apigateway.RestApi).restApiId;
+    const apiUrl = `https://${resolvedApiId}.execute-api.${base.aws_region}.amazonaws.com/prod/`;
 
     new cdk.CfnOutput(this, "METApiUrl",        { value: apiUrl });
     new cdk.CfnOutput(this, "METUserPoolId",     { value: userPool.userPoolId });

--- a/backend/scripts/deploy.sh
+++ b/backend/scripts/deploy.sh
@@ -90,6 +90,14 @@ STACK_NAME="MileageExpenseStack-${ID_PREFIX}"
 CLIENT_NAME="${ID_PREFIX}-met-client"
 API_NAME="${ID_PREFIX}-mileage-expense-api"
 
+# State file — persists API Gateway ID between deploys so it is never lost.
+# Gitignored alongside met_outputs.json.
+STATE_FILE="${REPO_ROOT}/.met_deploy_state"
+SAVED_API_ID=""
+if [ -f "$STATE_FILE" ]; then
+  SAVED_API_ID=$(grep -E '^api_id=' "$STATE_FILE" | cut -d= -f2 || true)
+fi
+
 echo "  Stack:         $STACK_NAME"
 echo "  Region:        $AWS_REGION"
 echo "  ID prefix:     $ID_PREFIX"
@@ -139,6 +147,18 @@ if [ -n "$EXISTING_API_ID" ] && [ "$EXISTING_API_ID" != "None" ]; then
   echo "  ✅ API Gateway exists: $EXISTING_API_ID"
   MET_API_ID="$EXISTING_API_ID"
 
+  # Warn if the live ID differs from saved state — means it was recreated
+  # and any installed iOS apps will be broken until rebuilt.
+  if [ -n "$SAVED_API_ID" ] && [ "$SAVED_API_ID" != "$MET_API_ID" ]; then
+    echo ""
+    echo "  ⚠️  WARNING: API Gateway ID has changed!"
+    echo "     Saved:  $SAVED_API_ID"
+    echo "     Live:   $MET_API_ID"
+    echo "     Any installed iOS apps with the old met_outputs.json will be broken."
+    echo "     You must rebuild and reinstall the iOS app after this deploy."
+    echo ""
+  fi
+
   # Fetch root resource ID so CDK can import the API without a custom resource
   MET_API_ROOT_ID=$(aws apigateway get-resources \
     --rest-api-id "$MET_API_ID" \
@@ -147,7 +167,17 @@ if [ -n "$EXISTING_API_ID" ] && [ "$EXISTING_API_ID" != "None" ]; then
     --output text)
   echo "  ✅ Root resource ID:   $MET_API_ROOT_ID"
 else
-  echo "  ℹ️  API Gateway not found — CDK will create it on first deploy."
+  if [ -n "$SAVED_API_ID" ]; then
+    echo ""
+    echo "  ⚠️  WARNING: Saved API ID '$SAVED_API_ID' no longer exists in AWS!"
+    echo "     The API Gateway was deleted. CDK will create a new one."
+    echo "     You MUST rebuild and reinstall the iOS app after this deploy."
+    echo ""
+    read -p "  Continue and create a new API Gateway? (y/n): " API_CONFIRM
+    if [[ "$API_CONFIRM" != "y" && "$API_CONFIRM" != "Y" ]]; then echo "  Cancelled."; exit 0; fi
+  else
+    echo "  ℹ️  API Gateway not found — CDK will create it on first deploy."
+  fi
   MET_API_ID=""
   MET_API_ROOT_ID=""
 fi
@@ -181,16 +211,20 @@ MET_API_ID="$MET_API_ID" \
 MET_API_ROOT_ID="$MET_API_ROOT_ID" \
   npx cdk deploy --require-approval never
 
-# ── Re-check API Gateway ID (if CDK just created it) ─────────────────────────
-if [ -z "$MET_API_ID" ]; then
-  echo ""
-  echo "  Resolving new API Gateway ID..."
-  MET_API_ID=$(aws apigateway get-rest-apis \
-    --region "$AWS_REGION" \
-    --query "items[?name=='${API_NAME}'].id" \
-    --output text)
-  echo "  ✅ API Gateway created: $MET_API_ID"
+# ── Re-check API Gateway ID (always verify from AWS after deploy) ────────────
+# Always re-resolve from AWS after CDK runs — never trust the pre-deploy ID.
+# This prevents met_outputs.json from being written with a stale/deleted API ID.
+echo ""
+echo "  Verifying API Gateway ID post-deploy..."
+MET_API_ID=$(aws apigateway get-rest-apis \
+  --region "$AWS_REGION" \
+  --query "items[?name=='${API_NAME}'].id" \
+  --output text)
+if [ -z "$MET_API_ID" ] || [ "$MET_API_ID" == "None" ]; then
+  echo "  ❌ Could not resolve API Gateway ID after deploy. Check CloudFormation console."
+  exit 1
 fi
+echo "  ✅ API Gateway ID: $MET_API_ID"
 
 # ── Capture CloudFormation outputs ───────────────────────────────────────────
 get_output() {
@@ -236,6 +270,13 @@ EOF
 
 echo ""
 echo "  ✅ met_outputs.json written to repo root"
+
+# ── Save state file ──────────────────────────────────────────────────────
+cat > "$STATE_FILE" << EOF
+api_id=${MET_API_ID}
+client_id=${MET_CLIENT_ID}
+EOF
+echo "  ✅ Deploy state saved to .met_deploy_state"
 echo ""
 echo "  ────────────────────────────────────────────────────"
 echo "  API URL:         $API_URL"

--- a/ios/MileageTracker893/MileageTracker893/Views/TripsView.swift
+++ b/ios/MileageTracker893/MileageTracker893/Views/TripsView.swift
@@ -365,12 +365,14 @@ struct TripDetailView: View {
         isSaving = true
         let startOdo = Double(startOdometer) ?? 0
         let endOdo   = Double(endOdometer)   ?? 0
+
+        // Use exactly what the user typed — empty field means zero, not "keep old value".
+        // This allows clearing odometer fields when switching to GPS-only.
         let odoDistSave: Double = {
             if endOdo > startOdo && startOdo > 0 { return endOdo - startOdo }
-            if let manual = Double(odometerDistance), manual > 0 { return manual }
-            return trip.odometerDistance
+            return Double(odometerDistance) ?? 0
         }()
-        let gpsDist = Double(gpsDistance) ?? trip.gpsDistance
+        let gpsDist = Double(gpsDistance) ?? 0
         do {
             let body = UpdateTripRequest(
                 vehicleId:        selectedVehicleId,


### PR DESCRIPTION
## Changes
- TripsView: edit trip no longer falls back to original odometer/GPS values when fields cleared
- deploy.sh: state file (.met_deploy_state) persists API Gateway ID between deploys
- deploy.sh: always re-resolves API ID post-deploy, never trusts pre-deploy value
- deploy.sh: warns loudly if API ID has changed or been deleted
- met-stack.ts: API URL always built from live restApiId not imported ID
- .gitignore: added .met_deploy_state